### PR TITLE
card command: Prevent results that were already matched and sent from being sent again

### DIFF
--- a/src/actions/card.js
+++ b/src/actions/card.js
@@ -54,6 +54,8 @@ module.exports = {
     async handle(bot, message, locale) {
         let matches = utils.findMatches(message.content, /\[(.*?)]/g);
 
+        let matchedCards = []; //Prevent cards that were already matched and sent from being sent again
+
         for(let match of matches) {
 
             let result = bot.nicknames.filter(nick => { return nick.name === match.toLowerCase() });
@@ -64,8 +66,6 @@ module.exports = {
                 }
                 return;
             }
-
-            let matchedCards = []; //Prevent cards that were already matched and sent from being sent again
 
             let langs = (locale === "en") ? ["en"] : [locale, "en"];
             for(let lang of langs) {

--- a/src/actions/card.js
+++ b/src/actions/card.js
@@ -65,16 +65,16 @@ module.exports = {
                 return;
             }
 
-            let matchedResults = []; //Prevent results that were already matched and sent from being sent again
+            let matchedCards = []; //Prevent cards that were already matched and sent from being sent again
 
             let langs = (locale === "en") ? ["en"] : [locale, "en"];
             for(let lang of langs) {
                 let result = bot.lisas[lang].findByAlias(match);
                 if(result.length === 1) {
-                    let singleResult = result[0];
-                    if (!matchedResults.includes(singleResult)) {
-                        message.channel.send(buildCardEmbed(bot, singleResult, locale));
-                        matchedResults.push(singleResult);
+                    let card = result[0];
+                    if (!matchedCards.includes(card)) {
+                        message.channel.send(buildCardEmbed(bot, card, locale));
+                        matchedCards.push(card);
                         break;
                     }
                 }

--- a/src/actions/card.js
+++ b/src/actions/card.js
@@ -65,12 +65,18 @@ module.exports = {
                 return;
             }
 
+            let matchedResults = []; //Prevent results that were already matched and sent from being sent again
+
             let langs = (locale === "en") ? ["en"] : [locale, "en"];
             for(let lang of langs) {
                 let result = bot.lisas[lang].findByAlias(match);
                 if(result.length === 1) {
-                    message.channel.send(buildCardEmbed(bot, result[0], locale));
-                    break;
+                    let singleResult = result[0];
+                    if (!matchedResults.includes(singleResult)) {
+                        message.channel.send(buildCardEmbed(bot, singleResult, locale));
+                        matchedResults.push(singleResult);
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Disclaimer: I have never written js before, and I'm not sure if this even runs or works, but to me it makes sense**

### Description
For the `card` command: Prevent results that were already matched and sent from being sent again

Currently, if you for example type `[spring] [marine] [spring]`, it will give you 3 separate embeds. With this PR it should give you only two, and skip the last one